### PR TITLE
Bump sdk versions 2.1.8x 3.1.2x

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -11,15 +11,6 @@ api = "0.2"
 
   [[metadata.dependencies]]
     id = "dotnet-sdk"
-    sha256 = "4c347c269189d3f6ff7321e505a4667f8c5fac2fcfb08a1d29f1f38d712f60c6"
-    source = "https://download.visualstudio.microsoft.com/download/pr/9ba4d9b0-3fca-40ed-b5a2-1552dfa4f89e/8e5e555b543a7afd8fd764e080d25671/dotnet-sdk-2.1.804-linux-x64.tar.gz"
-    source_sha256 = "51ce9fe209ed1ba5b077021fd23694808291ff8cf90dc56f04912b8cab9cb510"
-    stacks = ["io.buildpacks.stacks.bionic", "org.cloudfoundry.stacks.cflinuxfs3"]
-    uri = "https://buildpacks.cloudfoundry.org/dependencies/dotnet-sdk/dotnet-sdk.2.1.804.linux-amd64-any-stack-4c347c26.tar.xz"
-    version = "2.1.804"
-
-  [[metadata.dependencies]]
-    id = "dotnet-sdk"
     sha256 = "20bb1ae296012d3db829cbbe5574beb2b27139546e2673b0d8414d6a8c556d2b"
     source = "https://download.visualstudio.microsoft.com/download/pr/e730fe40-e2ea-42e5-a5d0-f86830d75849/571e5a2f4ebf9f8117878eeaad5cb19b/dotnet-sdk-2.1.805-linux-x64.tar.gz"
     source_sha256 = "af5241c99f58ddf26b4b934d681750fbe5da4245d5e528eb88a6e2c78ef54cde"
@@ -29,12 +20,12 @@ api = "0.2"
 
   [[metadata.dependencies]]
     id = "dotnet-sdk"
-    sha256 = "5f665939a6d9a6218fd98b24142f44ebee5387361dd871a4ad7659587f815f27"
-    source = "https://download.visualstudio.microsoft.com/download/pr/daec2daf-b458-4ae1-9046-b8ba09b5fb49/733e2d73b41640d6e6bdf1cc6b9ef03b/dotnet-sdk-3.1.200-linux-x64.tar.gz"
-    source_sha256 = "eca308c601e5d611af8203ac8d5aeb216a65a1038ac7238b6fcbed126ed54bde"
+    sha256 = "6f9c29da85a4c8be58023f3bb94100d4a597d7b4ee14477cc32bc7823bae7fb9"
+    source = "https://download.visualstudio.microsoft.com/download/pr/490da2e4-8f32-433d-8c2e-dd2a11088acd/cfba2ec3df2dedc2dd060b0f79f44b4e/dotnet-sdk-2.1.806-linux-x64.tar.gz"
+    source_sha256 = "82045e5ad60d2f38d642d2adb6091506fffb4b63b119f3dbdc3796515f8bcc76"
     stacks = ["io.buildpacks.stacks.bionic", "org.cloudfoundry.stacks.cflinuxfs3"]
-    uri = "https://buildpacks.cloudfoundry.org/dependencies/dotnet-sdk/dotnet-sdk_3.1.200_linux_x64_any-stack_5f665939.tar.xz"
-    version = "3.1.200"
+    uri = "https://buildpacks.cloudfoundry.org/dependencies/dotnet-sdk/dotnet-sdk_2.1.806_linux_x64_any-stack_6f9c29da.tar.xz"
+    version = "2.1.806"
 
   [[metadata.dependencies]]
     id = "dotnet-sdk"
@@ -45,21 +36,31 @@ api = "0.2"
     uri = "https://buildpacks.cloudfoundry.org/dependencies/dotnet-sdk/dotnet-sdk_3.1.201_linux_x64_any-stack_1904ac7d.tar.xz"
     version = "3.1.201"
 
-  [[metadata.runtime-to-sdks]]
-    runtime-version = "2.1.16"
-    sdks = ["2.1.804"]
+  [[metadata.dependencies]]
+    id = "dotnet-sdk"
+    sha256 = "a3b769a0ca981d62287e2a402eda79754d2c64a0e00eda66f06e2c093735d9c3"
+    source = "https://download.visualstudio.microsoft.com/download/pr/7d4c708b-38db-48b2-8532-9fc8a3ab0e42/23229fd17482119822bd9261b3570d87/dotnet-sdk-3.1.202-linux-x64.tar.gz"
+    source_sha256 = "835ecc219be32036f0e91fce7e9c1eeda1609ee26dc2b6089506b436af4a7fc3"
+    stacks = ["io.buildpacks.stacks.bionic", "org.cloudfoundry.stacks.cflinuxfs3"]
+    uri = "https://buildpacks.cloudfoundry.org/dependencies/dotnet-sdk/dotnet-sdk_3.1.202_linux_x64_any-stack_a3b769a0.tar.xz"
+    version = "3.1.202"
 
   [[metadata.runtime-to-sdks]]
     runtime-version = "2.1.17"
     sdks = ["2.1.805"]
 
   [[metadata.runtime-to-sdks]]
-    runtime-version = "3.1.2"
-    sdks = ["3.1.200"]
+    runtime-version = "2.1.18"
+    sdks = ["2.1.806"]
 
   [[metadata.runtime-to-sdks]]
     runtime-version = "3.1.3"
     sdks = ["3.1.201"]
+
+  [[metadata.runtime-to-sdks]]
+    runtime-version = "3.1.4"
+    sdks = ["3.1.202"]
+
 
 [[stacks]]
   id = "org.cloudfoundry.stacks.cflinuxfs3"

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -247,8 +247,8 @@ dotnet-sdk:
 
 		Expect(app.StartWithCommand("dotnet dotnet.dll --urls http://0.0.0.0:${PORT}")).To(Succeed())
 
-		Expect(app.BuildLogs()).To(MatchRegexp(fmt.Sprintf(`dotnet-runtime.%s`, `2\.1\.16`)))
-		Expect(app.BuildLogs()).To(MatchRegexp(fmt.Sprintf(`dotnet-runtime.%s`, `2\.1\.16`)))
+		Expect(app.BuildLogs()).To(MatchRegexp(fmt.Sprintf(`dotnet-runtime.%s`, `2\.1\.17`)))
+		Expect(app.BuildLogs()).To(MatchRegexp(fmt.Sprintf(`dotnet-runtime.%s`, `2\.1\.17`)))
 
 		Eventually(func() string {
 			body, _, _ := app.HTTPGet("/")
@@ -271,8 +271,8 @@ dotnet-sdk:
 			app.SetHealthCheck("stat /workspace", "2s", "15s")
 		}
 
-		Expect(app.BuildLogs()).To(MatchRegexp(fmt.Sprintf(`dotnet-runtime.%s`, `2\.1\.17`)))
-		Expect(app.BuildLogs()).To(MatchRegexp(fmt.Sprintf(`dotnet-runtime.%s`, `2\.1\.17`)))
+		Expect(app.BuildLogs()).To(MatchRegexp(fmt.Sprintf(`dotnet-runtime_%s`, `2\.1\.18`)))
+		Expect(app.BuildLogs()).To(MatchRegexp(fmt.Sprintf(`dotnet-runtime_%s`, `2\.1\.18`)))
 
 		Expect(app.StartWithCommand("dotnet dotnet.dll --urls http://0.0.0.0:${PORT}")).To(Succeed())
 

--- a/integration/testdata/fdd_apply_patches_false_2.1/dotnet.runtimeconfig.json
+++ b/integration/testdata/fdd_apply_patches_false_2.1/dotnet.runtimeconfig.json
@@ -3,7 +3,7 @@
     "tfm": "netcoreapp2.1",
     "framework": {
       "name": "Microsoft.AspNetCore.App",
-      "version": "2.1.16"
+      "version": "2.1.17"
     },
     "applyPatches": false,
     "configProperties": {


### PR DESCRIPTION
This PR replaces both #23 and #24, and resolves the deadlock cause by each. 