### PR TITLE
adds project file as version source in plan entry resolver

### DIFF
--- a/entry_resolver.go
+++ b/entry_resolver.go
@@ -55,6 +55,7 @@ func getPriority(source string) int {
 			"buildpack.yml":          3,
 			"global.json":            2,
 			`.*\.(cs)|(fs)|(vb)proj`: 1, // matches filename.(cs/fs/vb)proj
+			"runtimeconfig.json":     1,
 			"":                       -1,
 		}
 	)

--- a/entry_resolver.go
+++ b/entry_resolver.go
@@ -23,6 +23,7 @@ func (r PlanEntryResolver) Resolve(entries []packit.BuildpackPlanEntry) packit.B
 			"buildpack.yml":   3,
 			"global.json":     2,
 			"*sproj":          1,
+			"project file":    1,
 			"":                -1,
 		}
 	)

--- a/entry_resolver_test.go
+++ b/entry_resolver_test.go
@@ -94,45 +94,6 @@ func testPlanEntryResolver(t *testing.T, context spec.G, it spec.S) {
 		})
 	})
 
-	context("when a buildpack.yml and *sproj are both included", func() {
-		it("resolves the best plan entry", func() {
-			entry := resolver.Resolve([]packit.BuildpackPlanEntry{
-				{
-					Name: "dotnet-sdk",
-					Metadata: map[string]interface{}{
-						"version": "other-version",
-					},
-				},
-				{
-					Name: "dotnet-sdk",
-					Metadata: map[string]interface{}{
-						"version-source": "buildpack.yml",
-						"version":        "buildpack-yml-version",
-					},
-				},
-				{
-					Name: "dotnet-sdk",
-					Metadata: map[string]interface{}{
-						"version-source": "*sproj",
-						"version":        "*sproj-version",
-					},
-				},
-			})
-			Expect(entry).To(Equal(packit.BuildpackPlanEntry{
-				Name: "dotnet-sdk",
-				Metadata: map[string]interface{}{
-					"version-source": "buildpack.yml",
-					"version":        "buildpack-yml-version",
-				},
-			}))
-
-			Expect(buffer.String()).To(ContainSubstring("    Candidate version sources (in priority order):"))
-			Expect(buffer.String()).To(ContainSubstring("      buildpack.yml -> \"buildpack-yml-version\""))
-			Expect(buffer.String()).To(ContainSubstring("      *sproj        -> \"*sproj-version\""))
-			Expect(buffer.String()).To(ContainSubstring("      <unknown>     -> \"other-version\""))
-		})
-	})
-
 	context("when a buildpack.yml and project file are both included", func() {
 		it("resolves the best plan entry", func() {
 			entry := resolver.Resolve([]packit.BuildpackPlanEntry{
@@ -152,7 +113,7 @@ func testPlanEntryResolver(t *testing.T, context spec.G, it spec.S) {
 				{
 					Name: "dotnet-sdk",
 					Metadata: map[string]interface{}{
-						"version-source": "project file",
+						"version-source": "my-app.vbproj",
 						"version":        "project-file-version",
 					},
 				},
@@ -167,10 +128,11 @@ func testPlanEntryResolver(t *testing.T, context spec.G, it spec.S) {
 
 			Expect(buffer.String()).To(ContainSubstring("    Candidate version sources (in priority order):"))
 			Expect(buffer.String()).To(ContainSubstring("      buildpack.yml -> \"buildpack-yml-version\""))
-			Expect(buffer.String()).To(ContainSubstring("      project file  -> \"project-file-version\""))
+			Expect(buffer.String()).To(ContainSubstring("      my-app.vbproj -> \"project-file-version\""))
 			Expect(buffer.String()).To(ContainSubstring("      <unknown>     -> \"other-version\""))
 		})
 	})
+
 	context("when a buildpack.yml and global.json are both included", func() {
 		it("resolves the best plan entry", func() {
 			entry := resolver.Resolve([]packit.BuildpackPlanEntry{
@@ -209,45 +171,6 @@ func testPlanEntryResolver(t *testing.T, context spec.G, it spec.S) {
 			Expect(buffer.String()).To(ContainSubstring("      <unknown>     -> \"other-version\""))
 		})
 	})
-	context("when a global.json and a *sproj are both included", func() {
-		it("resolves the best plan entry", func() {
-			entry := resolver.Resolve([]packit.BuildpackPlanEntry{
-				{
-					Name: "dotnet-sdk",
-					Metadata: map[string]interface{}{
-						"version": "other-version",
-					},
-				},
-				{
-					Name: "dotnet-sdk",
-					Metadata: map[string]interface{}{
-						"version-source": "*sproj",
-						"version":        "*sproj-version",
-					},
-				},
-				{
-					Name: "dotnet-sdk",
-					Metadata: map[string]interface{}{
-						"version-source": "global.json",
-						"version":        "globaljson-version",
-					},
-				},
-			})
-			Expect(entry).To(Equal(packit.BuildpackPlanEntry{
-				Name: "dotnet-sdk",
-				Metadata: map[string]interface{}{
-					"version-source": "global.json",
-					"version":        "globaljson-version",
-				},
-			}))
-
-			Expect(buffer.String()).To(ContainSubstring("    Candidate version sources (in priority order):"))
-			Expect(buffer.String()).To(ContainSubstring("      global.json -> \"globaljson-version\""))
-			Expect(buffer.String()).To(ContainSubstring("      *sproj      -> \"*sproj-version\""))
-			Expect(buffer.String()).To(ContainSubstring("      <unknown>   -> \"other-version\""))
-		})
-	})
-
 	context("when a global.json and a project file are both included", func() {
 		it("resolves the best plan entry", func() {
 			entry := resolver.Resolve([]packit.BuildpackPlanEntry{
@@ -260,7 +183,7 @@ func testPlanEntryResolver(t *testing.T, context spec.G, it spec.S) {
 				{
 					Name: "dotnet-sdk",
 					Metadata: map[string]interface{}{
-						"version-source": "project file",
+						"version-source": "my-app.csproj",
 						"version":        "project-file-version",
 					},
 				},
@@ -281,9 +204,9 @@ func testPlanEntryResolver(t *testing.T, context spec.G, it spec.S) {
 			}))
 
 			Expect(buffer.String()).To(ContainSubstring("    Candidate version sources (in priority order):"))
-			Expect(buffer.String()).To(ContainSubstring("      global.json  -> \"globaljson-version\""))
-			Expect(buffer.String()).To(ContainSubstring("      project file -> \"project-file-version\""))
-			Expect(buffer.String()).To(ContainSubstring("      <unknown>    -> \"other-version\""))
+			Expect(buffer.String()).To(ContainSubstring("      global.json   -> \"globaljson-version\""))
+			Expect(buffer.String()).To(ContainSubstring("      my-app.csproj -> \"project-file-version\""))
+			Expect(buffer.String()).To(ContainSubstring("      <unknown>     -> \"other-version\""))
 		})
 	})
 
@@ -300,7 +223,7 @@ func testPlanEntryResolver(t *testing.T, context spec.G, it spec.S) {
 				{
 					Name: "dotnet-sdk",
 					Metadata: map[string]interface{}{
-						"version-source": "project file",
+						"version-source": "my-app.fsproj",
 						"version":        "project-file-version",
 					},
 				},
@@ -308,13 +231,13 @@ func testPlanEntryResolver(t *testing.T, context spec.G, it spec.S) {
 			Expect(entry).To(Equal(packit.BuildpackPlanEntry{
 				Name: "dotnet-sdk",
 				Metadata: map[string]interface{}{
-					"version-source": "project file",
+					"version-source": "my-app.fsproj",
 					"version":        "project-file-version",
 				},
 			}))
 
 			Expect(buffer.String()).To(ContainSubstring("    Candidate version sources (in priority order):"))
-			Expect(buffer.String()).To(ContainSubstring("      project file   -> \"project-file-version\""))
+			Expect(buffer.String()).To(ContainSubstring("      my-app.fsproj  -> \"project-file-version\""))
 			Expect(buffer.String()).To(ContainSubstring("      unknown source -> \"other-version\""))
 		})
 	})


### PR DESCRIPTION
Signed-off-by: Sophie Wigmore <swigmore@vmware.com>

<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->


Look for `project file` as a version source in plan resolver. Look for `*sproj` for now too until all buildpacks in the language family have moved over to `project file` from `*sproj`.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have added an integration test, if necessary.
