### PR TITLE
Always provides the DOTNET_ROOT and PATH environment variables

### DIFF
--- a/build_test.go
+++ b/build_test.go
@@ -233,13 +233,9 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 			},
 			Layers: []packit.Layer{
 				{
-					Name: "dotnet-core-sdk",
-					Path: filepath.Join(layersDir, "dotnet-core-sdk"),
-					SharedEnv: packit.Environment{
-						"PATH.prepend":         filepath.Join(workingDir, ".dotnet_root"),
-						"PATH.delim":           string(os.PathListSeparator),
-						"DOTNET_ROOT.override": filepath.Join(workingDir, ".dotnet_root"),
-					},
+					Name:      "dotnet-core-sdk",
+					Path:      filepath.Join(layersDir, "dotnet-core-sdk"),
+					SharedEnv: packit.Environment{},
 					BuildEnv:  packit.Environment{},
 					LaunchEnv: packit.Environment{},
 					Build:     true,
@@ -249,6 +245,18 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 						"dependency-sha": "some-sha",
 						"built_at":       timeStamp.Format(time.RFC3339Nano),
 					},
+				},
+				{
+					Name: "dotnet-env-var",
+					Path: filepath.Join(layersDir, "dotnet-env-var"),
+					SharedEnv: packit.Environment{
+						"PATH.prepend": filepath.Join(workingDir, ".dotnet_root"),
+						"PATH.delim":   string(os.PathListSeparator),
+					},
+					BuildEnv:  packit.Environment{},
+					LaunchEnv: packit.Environment{},
+					Build:     true,
+					Launch:    true,
 				},
 			},
 		}))

--- a/build_test.go
+++ b/build_test.go
@@ -250,8 +250,9 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 					Name: "dotnet-env-var",
 					Path: filepath.Join(layersDir, "dotnet-env-var"),
 					SharedEnv: packit.Environment{
-						"PATH.prepend": filepath.Join(workingDir, ".dotnet_root"),
-						"PATH.delim":   string(os.PathListSeparator),
+						"PATH.prepend":         filepath.Join(workingDir, ".dotnet_root"),
+						"PATH.delim":           string(os.PathListSeparator),
+						"DOTNET_ROOT.override": filepath.Join(workingDir, ".dotnet_root"),
 					},
 					BuildEnv:  packit.Environment{},
 					LaunchEnv: packit.Environment{},

--- a/integration/default_test.go
+++ b/integration/default_test.go
@@ -95,9 +95,9 @@ func testDefault(t *testing.T, context spec.G, it spec.S) {
 					// and its existence in the .dotnet_root directory (which is on the PATH) sufficiently proves
 					// its ability to be called. This may need refactoring if that assumption is proved insufficient.
 					MatchRegexp(`-rwxr-xr-x \d+ cnb cnb \d+ .* dotnet`),
-					MatchRegexp(`lrwxrwxrwx \d+ cnb cnb     \d+ .* packs -> /layers/paketo-buildpacks_dotnet-core-sdk/dotnet-core-sdk/packs`),
-					MatchRegexp(`lrwxrwxrwx \d+ cnb cnb     \d+ .* sdk -> /layers/paketo-buildpacks_dotnet-core-sdk/dotnet-core-sdk/sdk`),
-					MatchRegexp(`lrwxrwxrwx \d+ cnb cnb     \d+ .* templates -> /layers/paketo-buildpacks_dotnet-core-sdk/dotnet-core-sdk/templates`),
+					MatchRegexp(`lrwxrwxrwx \d+ cnb cnb \s+\d+ .* packs -> /layers/paketo-buildpacks_dotnet-core-sdk/dotnet-core-sdk/packs`),
+					MatchRegexp(`lrwxrwxrwx \d+ cnb cnb \s+\d+ .* sdk -> /layers/paketo-buildpacks_dotnet-core-sdk/dotnet-core-sdk/sdk`),
+					MatchRegexp(`lrwxrwxrwx \d+ cnb cnb \s+\d+ .* templates -> /layers/paketo-buildpacks_dotnet-core-sdk/dotnet-core-sdk/templates`),
 					MatchRegexp(`lrwxrwxrwx \d+ cnb cnb \d+ .* /workspace/.dotnet_root/sdk -> /layers/paketo-buildpacks_dotnet-core-sdk/dotnet-core-sdk/sdk`),
 				),
 			)

--- a/integration/layer_reuse_test.go
+++ b/integration/layer_reuse_test.go
@@ -111,9 +111,13 @@ func testLayerReuse(t *testing.T, context spec.G, it spec.S) {
 				"",
 				MatchRegexp(fmt.Sprintf("  Reusing cached layer /layers/%s/dotnet-core-sdk", strings.ReplaceAll(settings.BuildpackInfo.Buildpack.ID, "/", "_"))),
 				"",
+				"  Configuring environment",
+				`    DOTNET_ROOT -> "/workspace/.dotnet_root"`,
+				`    PATH        -> "/workspace/.dotnet_root:$PATH"`,
 			))
+
 			secondContainer, err = docker.Container.Run.
-				WithCommand("ls -al $DOTNET_ROOT && ls -al $DOTNET_ROOT/sdk").
+				WithCommand("ls -al $DOTNET_ROOT").
 				Execute(secondImage.ID)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -126,10 +130,7 @@ func testLayerReuse(t *testing.T, context spec.G, it spec.S) {
 			}).Should(
 				And(
 					MatchRegexp(`-rwxr-xr-x \d+ cnb cnb \d+ .* dotnet`),
-					MatchRegexp(`lrwxrwxrwx \d+ cnb cnb     \d+ .* packs -> /layers/paketo-buildpacks_dotnet-core-sdk/dotnet-core-sdk/packs`),
-					MatchRegexp(`lrwxrwxrwx \d+ cnb cnb     \d+ .* sdk -> /layers/paketo-buildpacks_dotnet-core-sdk/dotnet-core-sdk/sdk`),
-					MatchRegexp(`lrwxrwxrwx \d+ cnb cnb     \d+ .* templates -> /layers/paketo-buildpacks_dotnet-core-sdk/dotnet-core-sdk/templates`),
-					MatchRegexp(`lrwxrwxrwx \d+ cnb cnb \d+ .* /workspace/.dotnet_root/sdk -> /layers/paketo-buildpacks_dotnet-core-sdk/dotnet-core-sdk/sdk`),
+					MatchRegexp(`lrwxrwxrwx \d+ cnb cnb \s+\d+ .* sdk -> /layers/paketo-buildpacks_dotnet-core-sdk/dotnet-core-sdk/sdk`),
 				),
 			)
 

--- a/integration/offline_test.go
+++ b/integration/offline_test.go
@@ -93,9 +93,9 @@ func testOffline(t *testing.T, context spec.G, it spec.S) {
 			}).Should(
 				And(
 					MatchRegexp(`-rwxr-xr-x \d+ cnb cnb \d+ .* dotnet`),
-					MatchRegexp(`lrwxrwxrwx \d+ cnb cnb     \d+ .* packs -> /layers/paketo-buildpacks_dotnet-core-sdk/dotnet-core-sdk/packs`),
-					MatchRegexp(`lrwxrwxrwx \d+ cnb cnb     \d+ .* sdk -> /layers/paketo-buildpacks_dotnet-core-sdk/dotnet-core-sdk/sdk`),
-					MatchRegexp(`lrwxrwxrwx \d+ cnb cnb     \d+ .* templates -> /layers/paketo-buildpacks_dotnet-core-sdk/dotnet-core-sdk/templates`),
+					MatchRegexp(`lrwxrwxrwx \d+ cnb cnb \s+\d+ .* packs -> /layers/paketo-buildpacks_dotnet-core-sdk/dotnet-core-sdk/packs`),
+					MatchRegexp(`lrwxrwxrwx \d+ cnb cnb \s+\d+ .* sdk -> /layers/paketo-buildpacks_dotnet-core-sdk/dotnet-core-sdk/sdk`),
+					MatchRegexp(`lrwxrwxrwx \d+ cnb cnb \s+\d+ .* templates -> /layers/paketo-buildpacks_dotnet-core-sdk/dotnet-core-sdk/templates`),
 					MatchRegexp(`lrwxrwxrwx \d+ cnb cnb \d+ .* /workspace/.dotnet_root/sdk -> /layers/paketo-buildpacks_dotnet-core-sdk/dotnet-core-sdk/sdk`),
 				),
 			)


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This allows the environment variable to be set without including SDK
dependencies in the final running image

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have added an integration test, if necessary.
