### PR TITLE
Fixes map indexing bug in entry resolver

### DIFF
--- a/entry_resolver.go
+++ b/entry_resolver.go
@@ -51,23 +51,17 @@ func (r PlanEntryResolver) Resolve(entries []packit.BuildpackPlanEntry) packit.B
 func getPriority(source string) int {
 	var (
 		priorities = map[string]int{
-			"RUNTIME_VERSION":        4,
-			"buildpack.yml":          3,
-			"global.json":            2,
-			`.*\.(cs)|(fs)|(vb)proj`: 1, // matches filename.(cs/fs/vb)proj
-			"runtimeconfig.json":     1,
-			"":                       -1,
+			"RUNTIME_VERSION":    4,
+			"buildpack.yml":      3,
+			"global.json":        2,
+			"runtimeconfig.json": 1,
+			"":                   -1,
 		}
 	)
 
-	if priority, ok := priorities[source]; ok {
-		return priority
+	if match, _ := regexp.MatchString(`.*\.(cs)|(fs)|(vb)proj`, source); match {
+		return 1
 	}
 
-	for key, priority := range priorities {
-		if match, _ := regexp.MatchString(key, source); match {
-			return priority
-		}
-	}
-	return -1
+	return priorities[source]
 }


### PR DESCRIPTION
Signed-off-by: Timothy Hitchener <thitchener@vmware.com>

<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Fixes bug caused by nondeterminism in iterating through map keys in `getPriority()` function. Avoids iterating through map keys entirely.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have added an integration test, if necessary.
