### PR TITLE
replaces hardcoded layer names with buildpack metadata

### DIFF
--- a/integration/default_test.go
+++ b/integration/default_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/paketo-buildpacks/occam"
@@ -95,10 +96,10 @@ func testDefault(t *testing.T, context spec.G, it spec.S) {
 					// and its existence in the .dotnet_root directory (which is on the PATH) sufficiently proves
 					// its ability to be called. This may need refactoring if that assumption is proved insufficient.
 					MatchRegexp(`-rwxr-xr-x \d+ cnb cnb \d+ .* dotnet`),
-					MatchRegexp(`lrwxrwxrwx \d+ cnb cnb \s+\d+ .* packs -> /layers/paketo-buildpacks_dotnet-core-sdk/dotnet-core-sdk/packs`),
-					MatchRegexp(`lrwxrwxrwx \d+ cnb cnb \s+\d+ .* sdk -> /layers/paketo-buildpacks_dotnet-core-sdk/dotnet-core-sdk/sdk`),
-					MatchRegexp(`lrwxrwxrwx \d+ cnb cnb \s+\d+ .* templates -> /layers/paketo-buildpacks_dotnet-core-sdk/dotnet-core-sdk/templates`),
-					MatchRegexp(`lrwxrwxrwx \d+ cnb cnb \d+ .* /workspace/.dotnet_root/sdk -> /layers/paketo-buildpacks_dotnet-core-sdk/dotnet-core-sdk/sdk`),
+					MatchRegexp(fmt.Sprintf(`lrwxrwxrwx \d+ cnb cnb \s+\d+ .* packs -> /layers/%s/dotnet-core-sdk/packs`, strings.ReplaceAll(settings.BuildpackInfo.Buildpack.ID, "/", "_"))),
+					MatchRegexp(fmt.Sprintf(`lrwxrwxrwx \d+ cnb cnb \s+\d+ .* sdk -> /layers/%s/dotnet-core-sdk/sdk`, strings.ReplaceAll(settings.BuildpackInfo.Buildpack.ID, "/", "_"))),
+					MatchRegexp(fmt.Sprintf(`lrwxrwxrwx \d+ cnb cnb \s+\d+ .* templates -> /layers/%s/dotnet-core-sdk/templates`, strings.ReplaceAll(settings.BuildpackInfo.Buildpack.ID, "/", "_"))),
+					MatchRegexp(fmt.Sprintf(`lrwxrwxrwx \d+ cnb cnb \d+ .* /workspace/.dotnet_root/sdk -> /layers/%s/dotnet-core-sdk/sdk`, strings.ReplaceAll(settings.BuildpackInfo.Buildpack.ID, "/", "_"))),
 				),
 			)
 		})

--- a/integration/layer_reuse_test.go
+++ b/integration/layer_reuse_test.go
@@ -130,7 +130,7 @@ func testLayerReuse(t *testing.T, context spec.G, it spec.S) {
 			}).Should(
 				And(
 					MatchRegexp(`-rwxr-xr-x \d+ cnb cnb \d+ .* dotnet`),
-					MatchRegexp(`lrwxrwxrwx \d+ cnb cnb \s+\d+ .* sdk -> /layers/paketo-buildpacks_dotnet-core-sdk/dotnet-core-sdk/sdk`),
+					MatchRegexp(fmt.Sprintf(`lrwxrwxrwx \d+ cnb cnb \s+\d+ .* sdk -> /layers/%s/dotnet-core-sdk/sdk`, strings.ReplaceAll(settings.BuildpackInfo.Buildpack.ID, "/", "_"))),
 				),
 			)
 
@@ -245,10 +245,10 @@ dotnet-framework:
 			}).Should(
 				And(
 					MatchRegexp(`-rwxr-xr-x \d+ cnb cnb \d+ .* dotnet`),
-					MatchRegexp(`lrwxrwxrwx \d+ cnb cnb     \d+ .* packs -> /layers/paketo-buildpacks_dotnet-core-sdk/dotnet-core-sdk/packs`),
-					MatchRegexp(`lrwxrwxrwx \d+ cnb cnb     \d+ .* sdk -> /layers/paketo-buildpacks_dotnet-core-sdk/dotnet-core-sdk/sdk`),
-					MatchRegexp(`lrwxrwxrwx \d+ cnb cnb     \d+ .* templates -> /layers/paketo-buildpacks_dotnet-core-sdk/dotnet-core-sdk/templates`),
-					MatchRegexp(`lrwxrwxrwx \d+ cnb cnb \d+ .* /workspace/.dotnet_root/sdk -> /layers/paketo-buildpacks_dotnet-core-sdk/dotnet-core-sdk/sdk`),
+					MatchRegexp(fmt.Sprintf(`lrwxrwxrwx \d+ cnb cnb \s+\d+ .* packs -> /layers/%s/dotnet-core-sdk/packs`, strings.ReplaceAll(settings.BuildpackInfo.Buildpack.ID, "/", "_"))),
+					MatchRegexp(fmt.Sprintf(`lrwxrwxrwx \d+ cnb cnb \s+\d+ .* sdk -> /layers/%s/dotnet-core-sdk/sdk`, strings.ReplaceAll(settings.BuildpackInfo.Buildpack.ID, "/", "_"))),
+					MatchRegexp(fmt.Sprintf(`lrwxrwxrwx \d+ cnb cnb \s+\d+ .* templates -> /layers/%s/dotnet-core-sdk/templates`, strings.ReplaceAll(settings.BuildpackInfo.Buildpack.ID, "/", "_"))),
+					MatchRegexp(fmt.Sprintf(`lrwxrwxrwx \d+ cnb cnb \d+ .* /workspace/.dotnet_root/sdk -> /layers/%s/dotnet-core-sdk/sdk`, strings.ReplaceAll(settings.BuildpackInfo.Buildpack.ID, "/", "_"))),
 				),
 			)
 

--- a/integration/offline_test.go
+++ b/integration/offline_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -93,10 +94,10 @@ func testOffline(t *testing.T, context spec.G, it spec.S) {
 			}).Should(
 				And(
 					MatchRegexp(`-rwxr-xr-x \d+ cnb cnb \d+ .* dotnet`),
-					MatchRegexp(`lrwxrwxrwx \d+ cnb cnb \s+\d+ .* packs -> /layers/paketo-buildpacks_dotnet-core-sdk/dotnet-core-sdk/packs`),
-					MatchRegexp(`lrwxrwxrwx \d+ cnb cnb \s+\d+ .* sdk -> /layers/paketo-buildpacks_dotnet-core-sdk/dotnet-core-sdk/sdk`),
-					MatchRegexp(`lrwxrwxrwx \d+ cnb cnb \s+\d+ .* templates -> /layers/paketo-buildpacks_dotnet-core-sdk/dotnet-core-sdk/templates`),
-					MatchRegexp(`lrwxrwxrwx \d+ cnb cnb \d+ .* /workspace/.dotnet_root/sdk -> /layers/paketo-buildpacks_dotnet-core-sdk/dotnet-core-sdk/sdk`),
+					MatchRegexp(fmt.Sprintf(`lrwxrwxrwx \d+ cnb cnb \s+\d+ .* packs -> /layers/%s/dotnet-core-sdk/packs`, strings.ReplaceAll(settings.BuildpackInfo.Buildpack.ID, "/", "_"))),
+					MatchRegexp(fmt.Sprintf(`lrwxrwxrwx \d+ cnb cnb \s+\d+ .* sdk -> /layers/%s/dotnet-core-sdk/sdk`, strings.ReplaceAll(settings.BuildpackInfo.Buildpack.ID, "/", "_"))),
+					MatchRegexp(fmt.Sprintf(`lrwxrwxrwx \d+ cnb cnb \s+\d+ .* templates -> /layers/%s/dotnet-core-sdk/templates`, strings.ReplaceAll(settings.BuildpackInfo.Buildpack.ID, "/", "_"))),
+					MatchRegexp(fmt.Sprintf(`lrwxrwxrwx \d+ cnb cnb \d+ .* /workspace/.dotnet_root/sdk -> /layers/%s/dotnet-core-sdk/sdk`, strings.ReplaceAll(settings.BuildpackInfo.Buildpack.ID, "/", "_"))),
 				),
 			)
 		})


### PR DESCRIPTION
Signed-off-by: Timothy Hitchener <thitchener@vmware.com>

<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Rather than hard-coding layer names in expectations for log output, interpolate buildpack name from metadata.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have added an integration test, if necessary.
