### PR TITLE
Remove sdk 2.1.x due to Microsoft EOS

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -14,24 +14,6 @@ api = "0.2"
 
   [[metadata.dependencies]]
     id = "dotnet-sdk"
-    sha256 = "9b44cade1d23edbb4901def48f3a020607eae56467e9a154c95354404eb22ee9"
-    source = "https://download.visualstudio.microsoft.com/download/pr/fb3319a2-9b8b-47c5-bed8-22617fb0feb6/ffc365184f20e64f46ebe6d780c50049/dotnet-sdk-2.1.817-linux-x64.tar.gz"
-    source_sha256 = "df3a7bc2814d10487dcb7f251c1d5f84b1d6b3db66aa9acb841d0a09cd0a1cd6"
-    stacks = ["io.buildpacks.stacks.bionic", "org.cloudfoundry.stacks.cflinuxfs3"]
-    uri = "https://buildpacks.cloudfoundry.org/dependencies/dotnet-sdk/dotnet-sdk_2.1.817_linux_x64_any-stack_9b44cade.tar.xz"
-    version = "2.1.817"
-
-  [[metadata.dependencies]]
-    id = "dotnet-sdk"
-    sha256 = "d242de97223b9c7f98f42c1517a8be8dddb6f60d4f9479c265c945c73ec5ee1b"
-    source = "https://download.visualstudio.microsoft.com/download/pr/5797d98a-8faf-472d-925c-931ac542d3c8/e48942da88f4d9d653a7b5c0790e7724/dotnet-sdk-2.1.818-linux-x64.tar.gz"
-    source_sha256 = "c535f48eb27591520e607b5bc179cd033a1e2e061484a13ada299b8dc3ea969b"
-    stacks = ["io.buildpacks.stacks.bionic", "org.cloudfoundry.stacks.cflinuxfs3"]
-    uri = "https://buildpacks.cloudfoundry.org/dependencies/dotnet-sdk/dotnet-sdk_2.1.818_linux_x64_any-stack_d242de97.tar.xz"
-    version = "2.1.818"
-
-  [[metadata.dependencies]]
-    id = "dotnet-sdk"
     sha256 = "6c3b91d419e2a6edfcff6cebd30e5e14e6636a4199381fc1ec544247ba1ba9ef"
     source = "https://download.visualstudio.microsoft.com/download/pr/c7afc344-acf0-4a6c-8e53-4455f2bcfc85/321418f6300e475f6c5d52849efa2e2e/dotnet-sdk-3.1.411-linux-x64.tar.gz"
     source_sha256 = "8c4604852d44d4e23a9b68c50e8bce050e6119ee0fe5f3fc2cad3578a3992207"
@@ -65,14 +47,6 @@ api = "0.2"
     stacks = ["io.buildpacks.stacks.bionic", "org.cloudfoundry.stacks.cflinuxfs3"]
     uri = "https://buildpacks.cloudfoundry.org/dependencies/dotnet-sdk/dotnet-sdk_5.0.400_linux_x64_any-stack_a82d34b2.tar.xz"
     version = "5.0.400"
-
-  [[metadata.runtime-to-sdks]]
-    runtime-version = "2.1.29"
-    sdks = ["2.1.817"]
-
-  [[metadata.runtime-to-sdks]]
-    runtime-version = "2.1.30"
-    sdks = ["2.1.818"]
 
   [[metadata.runtime-to-sdks]]
     runtime-version = "3.1.17"

--- a/integration/layer_reuse_test.go
+++ b/integration/layer_reuse_test.go
@@ -174,7 +174,7 @@ func testLayerReuse(t *testing.T, context spec.G, it spec.S) {
 			var logs fmt.Stringer
 			err = ioutil.WriteFile(filepath.Join(source, "buildpack.yml"), []byte(`---
 dotnet-framework:
-  version: "2.*"
+  version: "3.*"
 `), os.ModePerm)
 			Expect(err).NotTo(HaveOccurred())
 


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

Removes .NET Core SDK version 2.1.X due to Microsoft EOS

## Use Cases
<!-- An explanation of the use cases your change enables -->

This is needed to get the integration tests passing for new PRs, since the version has already been removed in the .NET Core Runtime and ASPNet Core buildpacks. We will move to the dep-server in a separate PR.

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
