### PR TITLE
consume SDK from dep-server

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -48,6 +48,16 @@ api = "0.2"
     uri = "https://buildpacks.cloudfoundry.org/dependencies/dotnet-sdk/dotnet-sdk_5.0.401_linux_x64_any-stack_26fab11f.tar.xz"
     version = "5.0.401"
 
+  [[metadata.dependency-constraints]]
+    constraint = "3.1.*"
+    id = "dotnet-sdk"
+    patches = 2
+
+  [[metadata.dependency-constraints]]
+    constraint = "5.0.*"
+    id = "dotnet-sdk"
+    patches = 2
+
   [[metadata.runtime-to-sdks]]
     runtime-version = "3.1.17"
     sdks = ["3.1.411"]


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

Resolves #223. Once #256 is merged in, we will have workflows ready to bump the compatibility table when we get dependency updates, so we can safely make the switch over to consuming dependencies from the dep-server.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
