### PR TITLE
Quote SDK versions in trigger workflow

### DIFF
--- a/.github/workflows/trigger-compatibility-update.yml
+++ b/.github/workflows/trigger-compatibility-update.yml
@@ -22,7 +22,7 @@ jobs:
 
     - name: Trigger SDK Compatibility Table Updates
       run: |
-        IFS=', ' read -r -a versions <<< ${{ steps.parse.outputs.versions }}
+        IFS=', ' read -r -a versions <<< "${{ steps.parse.outputs.versions }}"
         for index in ${!versions[@]}; do
           echo ${versions[index]}
           curl -X POST \


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

Resolves issue seen in workflow run https://github.com/paketo-buildpacks/dotnet-core-sdk/runs/3874698280?check_suite_focus=true.

The line `IFS=', ' read -r -a versions <<<  1.2.3, 2.3.4` fails with ` read: 2.3.4: not a valid identifier` on Linux (this isn't the case on Darwin). Quoting the variable prevents this from occurring.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
