### PR TITLE
Add Jammy stack to .NET 6 dependencies

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -55,7 +55,7 @@ api = "0.8"
     sha256 = "813ace79fe4c7fe78ad223ee1df469de7f344641c5eb6540390fe23d05c667f2"
     source = "https://download.visualstudio.microsoft.com/download/pr/dc930bff-ef3d-4f6f-8799-6eb60390f5b4/1efee2a8ea0180c94aff8f15eb3af981/dotnet-sdk-6.0.300-linux-x64.tar.gz"
     source_sha256 = "1d4c8c90a5c32de9fc4e9872c79a97271abdff3a60fb55e36690e558d5697005"
-    stacks = ["io.buildpacks.stacks.bionic"]
+    stacks = ["io.buildpacks.stacks.bionic", "io.buildpacks.stacks.jammy"]
     uri = "https://deps.paketo.io/dotnet-sdk/dotnet-sdk_6.0.300_linux_x64_bionic_813ace79.tar.xz"
     version = "6.0.300"
 
@@ -69,7 +69,7 @@ api = "0.8"
     sha256 = "c4097c0891ae184483e4d84a12ee0132d2bfc1d7a5ff3761e7097dd30719b916"
     source = "https://download.visualstudio.microsoft.com/download/pr/77d472e5-194c-421e-992d-e4ca1d08e6cc/56c61ac303ddf1b12026151f4f000a2b/dotnet-sdk-6.0.301-linux-x64.tar.gz"
     source_sha256 = "57d146fac54f7c91686a2940d8f098aae91f998cd15b800f29fe88476af66cef"
-    stacks = ["io.buildpacks.stacks.bionic"]
+    stacks = ["io.buildpacks.stacks.bionic", "io.buildpacks.stacks.jammy"]
     uri = "https://deps.paketo.io/dotnet-sdk/dotnet-sdk_6.0.301_linux_x64_bionic_c4097c08.tar.xz"
     version = "6.0.301"
 
@@ -101,3 +101,5 @@ api = "0.8"
 
 [[stacks]]
   id = "io.buildpacks.stacks.bionic"
+[[stacks]]
+  id = "io.buildpacks.stacks.jammy"


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
The [Paketo Jammy Stacks RFC](https://github.com/paketo-buildpacks/rfcs/blob/ba9273ded6c65274276677b1ad5db5e61029060d/text/stacks/0004-jammy-jellyfish.md) has been accepted, and specifies that the Jammy Full and Base stacks will have the stack ID `io.buildpacks.stacks.jammy`. [.NET 3.1 does not work on Jammy Jellyfish](https://github.com/dotnet/core/issues/7038#issuecomment-1110377345) because it requires an outdated version of OpenSSL. So, this PR adds the Jammy stack only to the .NET 6 dependencies. 

A related [dep-server PR](https://github.com/paketo-buildpacks/dep-server/pull/179) will honor this change for new versions of .NET as they're added. Once this is approved, I'll also updated the existing `metadata.json` for the dependencies currently in the buildpack to reflect this change.

## Use Cases
<!-- An explanation of the use cases your change enables -->
Will allow the .NET Core buildpack to run on Jammy.

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).

