### PR TITLE
Remove .NET Core 7

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -33,20 +33,6 @@ api = "0.8"
     version = "6.0.423"
 
   [[metadata.dependencies]]
-    checksum = "sha512:20b8e02979328e4c4a14493f7791ed419aabd0175233db80cd60e2c004b829b3e8301281ea86b27ba818372473accf5a6d553e5354c54917c8e84d25f5855caa"
-    cpe = "cpe:2.3:a:microsoft:.net:7.0.410:*:*:*:*:*:*:*"
-    deprecation_date = "2024-05-14T00:00:00Z"
-    id = "dotnet-sdk"
-    licenses = ["JSON", "MIT", "MIT-0", "MIT-advertising", "MIT-feh", "X11-distribute-modifications-variant"]
-    name = ".NET Core SDK"
-    purl = "pkg:generic/dotnet-core-sdk@7.0.410?checksum=20b8e02979328e4c4a14493f7791ed419aabd0175233db80cd60e2c004b829b3e8301281ea86b27ba818372473accf5a6d553e5354c54917c8e84d25f5855caa&download_url=https://download.visualstudio.microsoft.com/download/pr/0ddc1522-2361-4394-97e9-52318bf51951/c5aef30601a86810f1f8ea89d42c26a0/dotnet-sdk-7.0.410-linux-x64.tar.gz"
-    source = "https://download.visualstudio.microsoft.com/download/pr/0ddc1522-2361-4394-97e9-52318bf51951/c5aef30601a86810f1f8ea89d42c26a0/dotnet-sdk-7.0.410-linux-x64.tar.gz"
-    source-checksum = "sha512:20b8e02979328e4c4a14493f7791ed419aabd0175233db80cd60e2c004b829b3e8301281ea86b27ba818372473accf5a6d553e5354c54917c8e84d25f5855caa"
-    stacks = ["io.buildpacks.stacks.bionic", "io.buildpacks.stacks.jammy"]
-    uri = "https://download.visualstudio.microsoft.com/download/pr/0ddc1522-2361-4394-97e9-52318bf51951/c5aef30601a86810f1f8ea89d42c26a0/dotnet-sdk-7.0.410-linux-x64.tar.gz"
-    version = "7.0.410"
-
-  [[metadata.dependencies]]
     checksum = "sha512:43d0ea1df12c15a0e47560d2a84857ab50eb04ac693ab41413c04c591719101c4c8165e052a42a66719c67bd07ac299ca47edbb4944a2901df765042e56b316f"
     cpe = "cpe:2.3:a:microsoft:.net:8.0.302:*:*:*:*:*:*:*"
     deprecation_date = "2026-11-10T00:00:00Z"
@@ -62,11 +48,6 @@ api = "0.8"
 
   [[metadata.dependency-constraints]]
     constraint = "6.0.*"
-    id = "dotnet-sdk"
-    patches = 1
-
-  [[metadata.dependency-constraints]]
-    constraint = "7.0.*"
     id = "dotnet-sdk"
     patches = 1
 

--- a/integration/layer_reuse_test.go
+++ b/integration/layer_reuse_test.go
@@ -172,7 +172,7 @@ func testLayerReuse(t *testing.T, context spec.G, it spec.S) {
 					settings.Buildpacks.BuildPlan.Online,
 				).
 				WithEnv(map[string]string{
-					"BP_DOTNET_FRAMEWORK_VERSION": "7.0.0",
+					"BP_DOTNET_FRAMEWORK_VERSION": "8.0.0",
 				}).
 				Execute(name, source)
 			Expect(err).NotTo(HaveOccurred(), logs.String())


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

Removes support for .NET 7 now it has gone out of support upstream. See https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core "Out of support versions"

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
